### PR TITLE
Support delete requests

### DIFF
--- a/src/docker/connection.cr
+++ b/src/docker/connection.cr
@@ -9,7 +9,7 @@ module Docker
     @ssl_context : OpenSSL::SSL::Context?
     @timeout : Int32? = nil
 
-    delegate :get, :post, :put, :patch, :head, to: client
+    delegate :get, :post, :put, :patch, :head, :delete, to: client
 
     getter url        : URI
     setter verify_tls : Bool?


### PR DESCRIPTION
Adds a delegate for the `delete` method through to the underlying `HTTP::Client`. This was breaking calls to [`Docker::Container#remove`](https://github.com/watzon/docker-api/blob/master/src/docker/container.cr#L284-L287).